### PR TITLE
ngx-masonry fix optimization bailouts.

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -29,6 +29,10 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
+            "allowedCommonJsDependencies": [
+              "ngx-masonry",
+              "masonry-layout"
+            ],
             "assets": [
               "src/favicon.ico",
               "src/assets"


### PR DESCRIPTION
depends on 'ngx-masonry'. CommonJS or AMD dependencies can cause optimization bailouts.